### PR TITLE
Fix: invalid URL typo in Contributing section

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ To install this gem onto your local machine, run `bundle exec rake install`. To 
 
 ## Contributing
 
-Bug reports and pull requests are welcome on GitHub at https://github.com/gustavodiel]/colorama. This project is intended to be a safe, welcoming space for collaboration, and contributors are expected to adhere to the [code of conduct](https://github.com/gustavodiel/colorama/blob/master/CODE_OF_CONDUCT.md).
+Bug reports and pull requests are welcome on GitHub at https://github.com/gustavodiel/colorama. This project is intended to be a safe, welcoming space for collaboration, and contributors are expected to adhere to the [code of conduct](https://github.com/gustavodiel/colorama/blob/master/CODE_OF_CONDUCT.md).
 
 ## License
 


### PR DESCRIPTION
In the [_Contributing_](https://github.com/gustavodiel/colorama#contributing) section, the link `https://github.com/gustavodiel]/colorama` in [README.md - Line 55](https://github.com/gustavodiel/colorama/blame/main/README.md#L55) should be `https://github.com/gustavodiel/colorama`, just casually saving the day one typo at a time. :man_artist:.